### PR TITLE
Fix compatibility with Qt 5.5

### DIFF
--- a/qaesencryption.cpp
+++ b/qaesencryption.cpp
@@ -353,7 +353,9 @@ QByteArray QAESEncryption::encode(const QByteArray rawText, const QByteArray key
     QByteArray alignedText(rawText);
     QByteArray ivTemp(iv);
 
-    alignedText.append(getPadding(rawText.size(), m_blocklen), 0); //filling the array with zeros
+    //Fill array with zeros
+    QByteArray padding(getPadding(rawText.size(), m_blocklen), 0);
+    alignedText.append(padding);
 
     //Preparation for CFB
     if (m_mode == CFB)


### PR DESCRIPTION
Thanks for this project! :-)

QByteArray &QByteArray::append(int count, char ch) was introduced in Qt 5.7.
This patch allows the project to be used with for example with the current Ubuntu LTS version (16.04 Xenial).