### PR TITLE
Add generate_export_header to be able compile with -DBUILD_SHARED_LIBS=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ add_library(QtAES)
 
 if(NOT QTAES_STANDALONE_BUILD)
     add_library(${PROJECT_NAME}::QtAES ALIAS QtAES)
+    include(GenerateExportHeader)
+    generate_export_header(QtAES EXPORT_MACRO_NAME QTAESSHARED_EXPORT)
 endif()
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}/QAESEncryption" "#include \"qaesencryption.h\"")


### PR DESCRIPTION
It seems that `generate_export_header(QtAES EXPORT_MACRO_NAME QTAESSHARED_EXPORT)` was removed in commit 93020ab6c69203aba49ef1fd43e3119b718195b8.

This causes issues when compiling the project with the `-DBUILD_SHARED_LIBS=ON` CMake flag. We use Qt-AES in Amazfish https://github.com/piggz/harbour-amazfish/issues/520, and we are trying to package it for Alpine Linux, which requires `-DBUILD_SHARED_LIBS=ON` to be enabled for such packages.

I wasn’t able to find an explanation for why it was removed.

It seems to have been either only partially removed or removed by mistake.

The `generate_export_header` macro generates the qtaes_export.h file, which is included here:
https://github.com/bricke/Qt-AES/blob/e55c81b502c89165ba3a0c94999ea7727b0f3030/qaesencryption.h#L5

I have added it back to CMake. The other option would be to remove the #include in qaesencryption.h.

Fixes: #68