### PR TITLE
Fix software CFB loop structure and add NIST known-answer test

### DIFF
--- a/qaesencryption.cpp
+++ b/qaesencryption.cpp
@@ -682,11 +682,12 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
             break;
         }
 #endif
-        result.append(byteXor(alignedText.left(m_blocklen), cipher(expandedKey, iv)));
-        for(int i=0; i < alignedText.size(); i+= m_blocklen) {
-            if (i+m_blocklen < alignedText.size())
-                result.append(byteXor(alignedText.mid(i+m_blocklen, m_blocklen),
-                                   cipher(expandedKey, result.mid(i, m_blocklen))));
+        // CFB encrypt: C[i] = AES_E(C[i-1]) XOR P[i], C[-1] = IV
+        QByteArray cfbFeedback(iv);
+        for (int i = 0; i < alignedText.size(); i += m_blocklen) {
+            QByteArray block = byteXor(alignedText.mid(i, m_blocklen), cipher(expandedKey, cfbFeedback));
+            result.append(block);
+            cfbFeedback = block;
         }
     }
     break;
@@ -850,13 +851,13 @@ QByteArray QAESEncryption::decode(const QByteArray &rawText, const QByteArray &k
             break;
         }
 #endif
-            ret.append(byteXor(rawText.mid(0, m_blocklen), cipher(expandedKey, iv)));
-            for(int i=0; i < rawText.size(); i+= m_blocklen){
-                if (i+m_blocklen < rawText.size()) {
-                    ret.append(byteXor(rawText.mid(i+m_blocklen, m_blocklen),
-                                       cipher(expandedKey, rawText.mid(i, m_blocklen))));
-                }
-            }
+        // CFB decrypt: P[i] = AES_E(C[i-1]) XOR C[i], C[-1] = IV
+        // Note: CFB uses the FORWARD cipher (AES_E) for decryption, not invCipher.
+        QByteArray cfbFeedback(iv);
+        for (int i = 0; i < rawText.size(); i += m_blocklen) {
+            ret.append(byteXor(rawText.mid(i, m_blocklen), cipher(expandedKey, cfbFeedback)));
+            cfbFeedback = rawText.mid(i, m_blocklen); // feedback is ciphertext, not plaintext
+        }
         }
         break;
     case OFB: {

--- a/unit_test/aestest.cpp
+++ b/unit_test/aestest.cpp
@@ -269,6 +269,24 @@ void AesTest::CBC128Decrypt()
 
 //=================== CFB TESTING ============================
 
+void AesTest::CFB128KnownAnswer()
+{
+    // NIST SP 800-38A, F.3.13/F.3.14 — CFB128-AES128 Encrypt/Decrypt (two blocks).
+    // Verifies both the software and (when built with AES-NI) hardware paths against
+    // authoritative vectors. Same key and IV as the OFB128 test.
+    //
+    // P1: 6bc1bee22e409f96e93d7e117393172a → C1: 3b3fd92eb72dad20333449f8e83cfb4a
+    // P2: ae2d8a571e03ac9c9eb76fac45af8e51 → C2: c8a64537a0b3a93fcde3cdad9f1ce58b
+    QByteArray pt = QByteArray::fromHex("6bc1bee22e409f96e93d7e117393172a"
+                                        "ae2d8a571e03ac9c9eb76fac45af8e51");
+    QByteArray ct = QByteArray::fromHex("3b3fd92eb72dad20333449f8e83cfb4a"
+                                        "c8a64537a0b3a93fcde3cdad9f1ce58b");
+
+    QAESEncryption enc(QAESEncryption::AES_128, QAESEncryption::CFB);
+    QCOMPARE(enc.encode(pt, key16, iv), ct);
+    QCOMPARE(enc.decode(ct, key16, iv), pt);
+}
+
 void AesTest::CFB256String()
 {
     QAESEncryption encryption(QAESEncryption::AES_256, QAESEncryption::CFB, QAESEncryption::PKCS7);

--- a/unit_test/aestest.h
+++ b/unit_test/aestest.h
@@ -26,6 +26,8 @@ private slots:
     void CBC128Crypt();
     void CBC128Decrypt();
 
+    void CFB128KnownAnswer();
+
     void CFB256String();
 
     void CFB256SmallSizeText();


### PR DESCRIPTION
The software CFB encode/decode used a pre-loop + conditional-skip pattern: it computed C[0] before the loop, then iterated with `if (i+blocklen < size)` to produce the remaining blocks. While correct, the structure was non-obvious and made it hard to verify against the algorithm definition or spot regressions.

Replace both paths with a clean single loop using an explicit feedback variable:

  Encode: C[i] = AES_E(feedback) XOR P[i], feedback = C[i]
  Decode: P[i] = AES_E(feedback) XOR C[i], feedback = C[i]

Output is byte-for-byte identical to the previous implementation and to the AES-NI path.

Add CFB128KnownAnswer test using NIST SP 800-38A F.3.13/F.3.14 vectors (AES-128, two blocks). This is an unconditional test that runs under both the software and AES-NI paths, giving authoritative confirmation that both produce correct output.