### PR TITLE
Add Padding::NONE for CFB and OFB stream cipher modes

### DIFF
--- a/qaesencryption.cpp
+++ b/qaesencryption.cpp
@@ -604,8 +604,9 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
     // NONE padding is only valid for stream cipher modes (CFB, OFB, CTR).
     // ECB and CBC require block-aligned input; reject unaligned input early.
     if (m_padding == Padding::NONE && (m_mode == ECB || m_mode == CBC)
-            && rawText.size() % m_blocklen != 0)
+            && rawText.size() % m_blocklen != 0) {
         return QByteArray();
+    }
 
         QByteArray expandedKey = expandKey(key, true);
         QByteArray alignedText(rawText);

--- a/qaesencryption.cpp
+++ b/qaesencryption.cpp
@@ -265,6 +265,8 @@ QByteArray QAESEncryption::getPadding(int currSize, int alignment)
         if (size > 0)
             return QByteArray (size - 1, 0x00).prepend('\x80');
         break;
+    case Padding::NONE:
+        return QByteArray();
     default:
         return QByteArray(size, 0x00);
         break;
@@ -599,6 +601,12 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
     if ((m_mode >= CBC && (iv.isEmpty() || iv.size() != m_blocklen)) || key.size() != m_keyLen)
            return QByteArray();
 
+    // NONE padding is only valid for stream cipher modes (CFB, OFB, CTR).
+    // ECB and CBC require block-aligned input; reject unaligned input early.
+    if (m_padding == Padding::NONE && (m_mode == ECB || m_mode == CBC)
+            && rawText.size() % m_blocklen != 0)
+        return QByteArray();
+
         QByteArray expandedKey = expandKey(key, true);
         QByteArray alignedText(rawText);
 
@@ -754,9 +762,12 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
 QByteArray QAESEncryption::decode(const QByteArray &rawText, const QByteArray &key, const QByteArray &iv, bool *ok)
 {
     if (ok) *ok = false;
-    // CTR ciphertext can be any length (stream cipher); all other modes must be block-aligned.
+    // Stream cipher modes with no padding allow arbitrary-length ciphertext.
+    const bool isStreamMode = (m_mode == CTR)
+                              || ((m_mode == CFB || m_mode == OFB) && m_padding == Padding::NONE);
+    // CTR/CFB(NONE)/OFB(NONE) ciphertext can be any length; all other modes must be block-aligned.
     if ((m_mode >= CBC && (iv.isEmpty() || iv.size() != m_blocklen)) || key.size() != m_keyLen
-            || (rawText.size() % m_blocklen != 0 && m_mode != CTR))
+            || (rawText.size() % m_blocklen != 0 && !isStreamMode))
            return QByteArray();
 
         QByteArray ret;

--- a/qaesencryption.h
+++ b/qaesencryption.h
@@ -52,7 +52,8 @@ public:
     enum Padding {
       ZERO,
       PKCS7,
-      ISO
+      ISO,
+      NONE  ///< No padding — valid only for CFB and OFB (stream cipher modes); allows arbitrary-length plaintext.
     };
 
     /*!

--- a/unit_test/aestest.cpp
+++ b/unit_test/aestest.cpp
@@ -827,3 +827,43 @@ void AesTest::AesNiOFB256RoundTrip()
     QCOMPARE(decoded, plain);
 }
 #endif
+
+// =================== NONE PADDING — STREAM CIPHER MODES ================
+
+void AesTest::CFBNoPaddingPartialBlock()
+{
+    // 7-byte plaintext — not block-aligned. NONE padding must round-trip exactly.
+    QAESEncryption enc(QAESEncryption::AES_128, QAESEncryption::CFB, QAESEncryption::NONE);
+    QByteArray plain("Hello!!");  // 7 bytes
+    QByteArray cipherText = enc.encode(plain, key16, iv);
+    QVERIFY(!cipherText.isEmpty());
+    QCOMPARE(cipherText.size(), plain.size());  // ciphertext must be same length as plaintext
+    QCOMPARE(enc.decode(cipherText, key16, iv), plain);
+}
+
+void AesTest::OFBNoPaddingPartialBlock()
+{
+    // 13-byte plaintext — not block-aligned. NONE padding must round-trip exactly.
+    QAESEncryption enc(QAESEncryption::AES_256, QAESEncryption::OFB, QAESEncryption::NONE);
+    QByteArray plain("Hello, World!");  // 13 bytes
+    QByteArray cipherText = enc.encode(plain, key32, iv);
+    QVERIFY(!cipherText.isEmpty());
+    QCOMPARE(cipherText.size(), plain.size());
+    QCOMPARE(enc.decode(cipherText, key32, iv), plain);
+}
+
+void AesTest::NoPaddingRejectedForECB()
+{
+    // ECB requires block-aligned input; NONE + unaligned must be rejected.
+    QAESEncryption enc(QAESEncryption::AES_128, QAESEncryption::ECB, QAESEncryption::NONE);
+    QByteArray plain("unaligned");  // 9 bytes — not a multiple of 16
+    QVERIFY(enc.encode(plain, key16).isEmpty());
+}
+
+void AesTest::NoPaddingRejectedForCBC()
+{
+    // CBC requires block-aligned input; NONE + unaligned must be rejected.
+    QAESEncryption enc(QAESEncryption::AES_256, QAESEncryption::CBC, QAESEncryption::NONE);
+    QByteArray plain("short");  // 5 bytes
+    QVERIFY(enc.encode(plain, key32, iv).isEmpty());
+}

--- a/unit_test/aestest.h
+++ b/unit_test/aestest.h
@@ -38,6 +38,11 @@ private slots:
     void OFB128Crypt();
     void OFB256String();
 
+    void CFBNoPaddingPartialBlock();
+    void OFBNoPaddingPartialBlock();
+    void NoPaddingRejectedForECB();
+    void NoPaddingRejectedForCBC();
+
     void CTR128KnownAnswer();
     void CTR192KnownAnswer();
     void CTR256KnownAnswer();


### PR DESCRIPTION
CFB and OFB are stream cipher modes and do not inherently require block-aligned input. With Padding::NONE, encode() and decode() skip padding entirely, producing ciphertext exactly the same length as the plaintext.

Changes:
- Add Padding::NONE to the public enum (CFB/OFB only; ECB/CBC reject unaligned input with an empty return and ok=false)
- getPadding(): explicit NONE case returns QByteArray() (previously fell through to the default ZERO behaviour)
- decode(): relax the block-alignment check so CFB and OFB with Padding::NONE accept non-block-aligned ciphertext, matching CTR
- Add four unit tests: CFB/OFB partial-block round-trips, and NONE+ECB / NONE+CBC rejection tests