### PR TITLE
Fix AES-NI secureZero to use actual expanded key size per level

### DIFF
--- a/qaesencryption.cpp
+++ b/qaesencryption.cpp
@@ -295,7 +295,7 @@ QByteArray QAESEncryption::expandKey(const QByteArray &key, bool isEncryptionKey
               QByteArray expKey;
               expKey.resize(aes128.expandedKey);
               memcpy(expKey.data(), (char*) aesKey.KEY, aes128.expandedKey);
-              secureZero(aesKey.KEY, 240);
+              secureZero(aesKey.KEY, aes128.expandedKey);
               return expKey;
           }
               break;
@@ -311,7 +311,7 @@ QByteArray QAESEncryption::expandKey(const QByteArray &key, bool isEncryptionKey
               QByteArray expKey;
               expKey.resize(aes192.expandedKey);
               memcpy(expKey.data(), (char*) aesKey.KEY, aes192.expandedKey);
-              secureZero(aesKey.KEY, 240);
+              secureZero(aesKey.KEY, aes192.expandedKey);
               return expKey;
           }
               break;
@@ -327,7 +327,7 @@ QByteArray QAESEncryption::expandKey(const QByteArray &key, bool isEncryptionKey
               QByteArray expKey;
               expKey.resize(aes256.expandedKey);
               memcpy(expKey.data(), (char*) aesKey.KEY, aes256.expandedKey);
-              secureZero(aesKey.KEY, 240);
+              secureZero(aesKey.KEY, aes256.expandedKey);
               return expKey;
           }
               break;


### PR DESCRIPTION
secureZero was called with the hard-coded value 240 for all AES levels, but AES-128 and AES-192 only write 176 and 208 bytes respectively into AES_KEY.KEY. The remaining bytes are uninitialized stack memory, not key material. Use the level-specific expandedKey constant to zero exactly the bytes that hold key schedule data.