### PR TITLE
CI: upgrade fuzzing action to v4, add Windows Qt 5.15.2 matrix entry

### DIFF
--- a/.github/workflows/ci-fuzzing.yml
+++ b/.github/workflows/ci-fuzzing.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Qt ${{ matrix.qt }}
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: ${{ matrix.qt }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
           - os: windows-latest
             qt_version: "6.7.0"
             qt_modules: ""
+          - os: windows-latest
+            qt_version: "5.15.2"
+            qt_modules: ""
           - os: macos-latest
             qt_version: "6.7.0"
             qt_modules: ""


### PR DESCRIPTION
## Summary

- Upgrade `jurplel/install-qt-action` from `@v3` to `@v4` in `ci-fuzzing.yml` to match all other workflows
- Add `windows-latest` / Qt `5.15.2` entry to the `ci.yml` matrix — Windows was only testing Qt 6.7.0 while Ubuntu tested both 6.7.0 and 5.15.2

## Test plan

- [ ] Fuzzing CI passes with the updated action version
- [ ] New Windows Qt 5.15.2 matrix entry builds and tests successfully