### PR TITLE
Enable compiler hardening flags for Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,10 +31,24 @@ if(QTAES_STANDALONE_BUILD)
             -Wextra
             -pedantic
             $<$<BOOL:${QTAES_ENABLE_WERROR}>:-Werror>)
+
+        # Hardening flags for Release builds.
+        # -fstack-protector-strong: emit stack canaries for functions with
+        #   addressable local buffers — catches stack-based buffer overflows.
+        # -D_FORTIFY_SOURCE=2: enables glibc bounds-checking on string/memory
+        #   functions at both compile time and runtime.
+        # These are standard practice for security-sensitive libraries and have
+        # negligible performance impact.
+        add_compile_options(
+            $<$<CONFIG:Release,RelWithDebInfo>:-fstack-protector-strong>
+            $<$<CONFIG:Release,RelWithDebInfo>:-D_FORTIFY_SOURCE=2>)
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
         add_compile_options(
             /W4
-            $<$<BOOL:${QTAES_ENABLE_WERROR}>:/WX>)
+            $<$<BOOL:${QTAES_ENABLE_WERROR}>:/WX>
+            # MSVC equivalent: enable basic security checks and SDL checks
+            $<$<CONFIG:Release,RelWithDebInfo>:/GS>
+            $<$<CONFIG:Release,RelWithDebInfo>:/sdl>)
     endif()
 endif()
 


### PR DESCRIPTION
## Summary

- Add `-fstack-protector-strong` and `-D_FORTIFY_SOURCE=2` for GCC/Clang Release/RelWithDebInfo builds
- Add `/GS` and `/sdl` for MSVC Release/RelWithDebInfo builds
- Flags are scoped to Release builds only — no impact on Debug or custom build types

## What the flags do

- **`-fstack-protector-strong`**: emits stack canaries for functions with addressable local buffers, catching stack-based buffer overflows at runtime
- **`-D_FORTIFY_SOURCE=2`**: enables glibc bounds-checking on string/memory functions at both compile time and runtime
- **`/GS`** (MSVC): buffer security checks (on by default in MSVC, made explicit here)
- **`/sdl`** (MSVC): enables additional Security Development Lifecycle checks

## Test plan

- [x] Full test suite passes with hardening flags enabled