### PR TITLE
Security hardening, O(n²) fixes, and empty-input tests

### DIFF
--- a/qaesencryption.cpp
+++ b/qaesencryption.cpp
@@ -622,6 +622,9 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
                             alignedText.size(),
                             expandedKey.constData(),
                             m_nr);
+            // Zero the stack copy of the IV — it contains chained block state
+            // that could theoretically be used to reconstruct plaintext blocks.
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif
@@ -645,6 +648,7 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
                             alignedText.size(),
                             expandedKey.constData(),
                             m_nr);
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif
@@ -669,6 +673,7 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
                            alignedText.size(),
                            expandedKey.constData(),
                            m_nr);
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif
@@ -687,6 +692,7 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
                            alignedText.size(),
                            expandedKey.constData(),
                            m_nr);
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif
@@ -760,6 +766,7 @@ QByteArray QAESEncryption::decode(const QByteArray &rawText, const QByteArray &k
                             rawText.size(),
                             expandedKey.constData(),
                             m_nr);
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif
@@ -784,6 +791,7 @@ QByteArray QAESEncryption::decode(const QByteArray &rawText, const QByteArray &k
                             rawText.size(),
                             expandedKey.constData(),
                             m_nr);
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif
@@ -808,6 +816,7 @@ QByteArray QAESEncryption::decode(const QByteArray &rawText, const QByteArray &k
                            rawText.size(),
                            expandedKey.constData(),
                            m_nr);
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif
@@ -827,6 +836,7 @@ QByteArray QAESEncryption::decode(const QByteArray &rawText, const QByteArray &k
                            rawText.size(),
                            expandedKey.constData(),
                            m_nr);
+            secureZero(ivec, sizeof(ivec));
             break;
         }
 #endif

--- a/qaesencryption.cpp
+++ b/qaesencryption.cpp
@@ -329,10 +329,10 @@ QByteArray QAESEncryption::expandKey(const QByteArray &key, bool isEncryptionKey
             tempa[2] = getSBoxValue(tempa[2]);
             tempa[3] = getSBoxValue(tempa[3]);
         }
-        roundKey.insert(i * 4 + 0, static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 0)) ^ tempa[0]);
-        roundKey.insert(i * 4 + 1, static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 1)) ^ tempa[1]);
-        roundKey.insert(i * 4 + 2, static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 2)) ^ tempa[2]);
-        roundKey.insert(i * 4 + 3, static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 3)) ^ tempa[3]);
+        roundKey[i * 4 + 0] = static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 0)) ^ tempa[0];
+        roundKey[i * 4 + 1] = static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 1)) ^ tempa[1];
+        roundKey[i * 4 + 2] = static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 2)) ^ tempa[2];
+        roundKey[i * 4 + 3] = static_cast<quint8>(roundKey.at((i - m_nk) * 4 + 3)) ^ tempa[3];
       }
       return roundKey;
   }
@@ -474,14 +474,11 @@ void QAESEncryption::invShiftRows(QByteArray &state)
 
 QByteArray QAESEncryption::byteXor(const QByteArray &a, const QByteArray &b)
 {
-  QByteArray::const_iterator it_a = a.begin();
-  QByteArray::const_iterator it_b = b.begin();
-  QByteArray ret;
-
-  for(int i = 0; i < std::min(a.size(), b.size()); i++)
-      ret.insert(i,it_a[i] ^ it_b[i]);
-
-  return ret;
+    const int n = std::min(a.size(), b.size());
+    QByteArray ret(n, 0);
+    for (int i = 0; i < n; i++)
+        ret[i] = static_cast<quint8>(a[i]) ^ static_cast<quint8>(b[i]);
+    return ret;
 }
 
 // Cipher is the main function that encrypts the PlainText.
@@ -584,12 +581,12 @@ QByteArray QAESEncryption::encode(const QByteArray &rawText, const QByteArray &k
         return QByteArray();
     }
 
-        QByteArray expandedKey = expandKey(key, true);
-        QByteArray alignedText(rawText);
+    QByteArray expandedKey = expandKey(key, true);
+    QByteArray alignedText(rawText);
 
-        // CTR is a stream cipher — no padding required; all other modes need block alignment.
-        if (m_mode != CTR)
-            alignedText.append(getPadding(rawText.size(), m_blocklen));
+    // CTR is a stream cipher — no padding required; all other modes need block alignment.
+    if (m_mode != CTR)
+        alignedText.append(getPadding(rawText.size(), m_blocklen));
 
     QByteArray result;
     switch(m_mode)

--- a/unit_test/aestest.cpp
+++ b/unit_test/aestest.cpp
@@ -877,3 +877,24 @@ void AesTest::CtSboxInverseMatchesTable()
         QCOMPARE(AesCt::invSbox(static_cast<quint8>(i)), expected[i]);
 }
 #endif
+
+void AesTest::EmptyInputECB()
+{
+    // Empty plaintext with PKCS7 padding must produce one full block of padding (16 bytes).
+    // This exercises the edge case where getPadding() fills an entire block.
+    QAESEncryption enc(QAESEncryption::AES_256, QAESEncryption::ECB, QAESEncryption::PKCS7);
+    QByteArray cipher = enc.encode(QByteArray(), key32);
+    QCOMPARE(cipher.size(), 16);
+    QByteArray decoded = enc.removePadding(enc.decode(cipher, key32));
+    QCOMPARE(decoded, QByteArray());
+}
+
+void AesTest::EmptyInputCBC()
+{
+    // Same check for CBC mode — empty plaintext round-trips correctly.
+    QAESEncryption enc(QAESEncryption::AES_256, QAESEncryption::CBC, QAESEncryption::PKCS7);
+    QByteArray cipher = enc.encode(QByteArray(), key32, iv);
+    QCOMPARE(cipher.size(), 16);
+    QByteArray decoded = enc.removePadding(enc.decode(cipher, key32, iv));
+    QCOMPARE(decoded, QByteArray());
+}

--- a/unit_test/aestest.h
+++ b/unit_test/aestest.h
@@ -103,6 +103,9 @@ private slots:
     void CtSboxInverseMatchesTable();
 #endif
 
+    void EmptyInputECB();
+    void EmptyInputCBC();
+
     void cleanupTestCase(){}
 
 private:


### PR DESCRIPTION
## Summary

- **ivec zeroing**: `secureZero()` all 8 `ivec[16]` stack copies after AES-NI calls — defence-in-depth against stack-scraping
- **`expandKey()` O(n²) fix**: replace `insert()` with `operator[]` on the pre-allocated array — avoids data shifting and keeps the key schedule at the correct size
- **`byteXor()` cleanup**: pre-allocate result and write via `operator[]`, dropping the now-unnecessary iterator variables
- **`encode()` indentation**: fix misaligned block
- **Empty-input tests**: `EmptyInputECB` and `EmptyInputCBC` — empty plaintext with PKCS7 must produce one full padding block and round-trip correctly

## Test plan

- [x] `EmptyInputECB` and `EmptyInputCBC` pass
- [x] Full test suite passes